### PR TITLE
update: README.md incluye link a CTfP.pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,3 +373,5 @@ Esta colección reúne archivos, enlaces y herramientas esenciales para aprender
 - [Parte 03_Avanzado.](https://terabox.com/s/1tvDxXws-Vjsuf9W6JSkvfw?authuser=3)
 ### Desarrollo de android con Kotlin ---
 - [Desarrollo de android con Kotlin.](https://terabox.com/s/1tRyIG-s6uIFi5AA7g97cig?authuser=3)
+### Programación Funcional ---
+- [Category Theory for programmers&nbsp;&nbsp;(Teoría de categorias para programadores)](https://terabox.com/s/14oAL5ZYR5YMmyMD5DlOFbQ)


### PR DESCRIPTION
Ahora el README.md incluye un link con enlace al libro "Category Theory for Programmers". 

P.D: El libro tiene licensia "Creative Commons" 